### PR TITLE
Fail integration when no worker is found

### DIFF
--- a/int/int_test.go
+++ b/int/int_test.go
@@ -39,6 +39,7 @@ func setMachineSetLabel(machineset machinev1.MachineSet, label string, value str
 func setNodeLabel(machineset machinev1.MachineSet, label string, value string) {
 	machines, err := m.GetMachinesForMachineSet(i.Client, &machineset)
 	Expect(err).ToNot(HaveOccurred())
+	Expect(len(machines)).To(BeNumerically(">", 0))
 	for _, machine := range machines {
 		node, err := m.GetNodeForMachine(i.Client, machine)
 		Expect(err).ToNot(HaveOccurred())
@@ -67,6 +68,7 @@ WAIT:
 		time.Sleep(1 * time.Second)
 		machines, err := m.GetMachinesForMachineSet(i.Client, &machineset)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(len(machines)).To(BeNumerically(">", 0))
 		allMachinesOk := true
 		for _, machine := range machines {
 			if !nodeOnly {
@@ -104,6 +106,7 @@ WAIT:
 		time.Sleep(1 * time.Second)
 		machines, err := m.GetMachinesForMachineSet(i.Client, &machineset)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(len(machines)).To(BeNumerically(">", 0))
 		allMachinesOk := true
 		for _, machine := range machines {
 			_, ok := machine.Spec.Labels[label]

--- a/int/integration.go
+++ b/int/integration.go
@@ -63,6 +63,11 @@ func (i *Integration) GetWorkerMachineSet() (machinev1.MachineSet, error) {
 		if ok && role == "worker" {
 			return ms, nil
 		}
+		role, ok = ms.Labels["machine.openshift.io/cluster-api-machine-role"]
+		if ok && role == "worker" {
+			return ms, nil
+		}
+
 	}
 	return machinev1.MachineSet{}, fmt.Errorf("no worker MachineSet found")
 }


### PR DESCRIPTION
* When a machineset exists but no machine matches, the integration tests
  will fail.
* Select worker machineset based on a second label, allowing to run the tests against
  CRC (but they will fail).