### PR TITLE
[WIP] Make deploy scripts work with minikube docker daemon

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -26,9 +26,10 @@ if image_exists_in_repo "${OPERATOR_IMAGE_URI}"; then
     echo "Skipping operator image build/push"
 else
     # build and push the operator image
-    BUILD_CMD="docker build" IMG="$OPERATOR_IMAGE_URI" make docker-build
+    #BUILD_CMD="docker build" IMG="$OPERATOR_IMAGE_URI" make docker-build
     if [[ ${DRY_RUN} != 'y' ]] ; then
       skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+        --src-cert-dir=$DOCKER_CERT_PATH --src-daemon-host=$DOCKER_HOST \
         "docker-daemon:${OPERATOR_IMAGE_URI}" \
         "docker://${OPERATOR_IMAGE_URI}"
     fi

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -131,9 +131,11 @@ fi
 
 # push image
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    --src-cert-dir=$DOCKER_CERT_PATH --src-daemon-host=$DOCKER_HOST \
     "docker-daemon:${REGISTRY_IMAGE}:${BRANCH_CHANNEL}-latest" \
     "docker://${REGISTRY_IMAGE}:${BRANCH_CHANNEL}-latest"
 
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    --src-cert-dir=$DOCKER_CERT_PATH --src-daemon-host=$DOCKER_HOST \
     "docker-daemon:${REGISTRY_IMAGE}:${BRANCH_CHANNEL}-latest" \
     "docker://${REGISTRY_IMAGE}:${BRANCH_CHANNEL}-${GIT_HASH}"


### PR DESCRIPTION
skopeo (used to publish the locally built docker image to quay.io) doesnt play nicely with the minikube docker daemon:
```
$ ./hack/app_sre_build_deploy.sh
Successfully built 0d07e9ba68f0
Successfully tagged quay.io/mstratto/managed-node-metadata-operator:be3a022
docker tag quay.io/mstratto/managed-node-metadata-operator:be3a022 quay.io/mstratto/managed-node-metadata-operator:latest
+ [[ '' != \y ]]
+ skopeo copy --dest-creds mstratto:me+vKCBJtsZ9j16jCu1BXY83MOlTAykCaDmBiKv4i8p051XeX0bBAWMcZJte2dcM docker-daemon:quay.io/mstratto/managed-node-metadata-operator:be3a022 docker://quay.io/mstratto/managed-node-metadata-operator:be3a022
FATA[0000] initializing source docker-daemon:quay.io/mstratto/managed-node-metadata-operator:be3a022: loading image from docker engine: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

I was unable to find a way to make it work without modifying these scripts and I havent been able to test is against non-minikube docker to make sure it works there as well. There is also at least one usage of docker-daemon in the boilerplate sub dir (./boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh) that I am reluctant to touch.

I dont like it...