### PR TITLE
Add OperatorName and OperatorNamespace to config.go

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,1 +1,6 @@
 package config
+
+const (
+	OperatorName      string = "managed-node-metadata-operator"
+	OperatorNamespace string = "openshift-managed-node-metadata-operator"
+)


### PR DESCRIPTION
This build is currently broken on `main` with the following error:
```
11:43:58 Error querying the repository for quay.io/app-sre/:v0.1.76-724c119:
11:43:58 stdout: 
11:43:58 stderr: time="2022-08-31T15:43:58Z" level=fatal msg="Error parsing image name \"docker://quay.io/app-sre/:v0.1.76-724c119\": invalid reference format"
```

Adding these two parameters to the config should populate the image name properly.

I don't believe the namespace is required, but it doesn't hurt.