### PR TITLE
env var is required by boilerplate

### DIFF
--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -35,6 +35,9 @@ spec:
             - --enable-leader-election
           command:
             - /manager
+          env:
+            - name: OPERATOR_NAME
+              value: "managed-node-metadata-operator"
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
So apparently having an environment variable is required by boilerplate...

The CI build logs say:
```
11:32:21 Generating CSV for version: 0.1.82-592e433
11:32:21 Loading ServiceAccount managed-node-metadata-operator from deploy/10_serviceaccount.yaml
11:32:21 Loading ClusterRole managed-node-metadata-operator from deploy/15_clusterrole.yaml
11:32:21 Loading ClusterRoleBinding managed-node-metadata-operator from deploy/16_clusterrolebinding.yaml
11:32:21 Loading Deployment managed-node-metadata-operator from deploy/20_operator.yaml
11:32:21 Loading Service managed-node-metadata-operator-metrics-service from deploy/30_metrics_service.yaml
11:32:21 Loading ServiceMonitor managed-node-metadata-operator-metrics-monitor from deploy/30_servicemonitor.yaml
11:32:21 Processing ClusterRole managed-node-metadata-operator
11:32:21   Discovered ServiceAccount managed-node-metadata-operator.
11:32:21 Traceback (most recent call last):
11:32:21   File "./boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py", line 322, in <module>
11:32:21     env = deploy['spec']['template']['spec']['containers'][0]['env']
11:32:21 KeyError: 'env'
11:32:21 make[1]: *** [staging-csv-build] Error 1
11:32:21 make[1]: Leaving directory `/var/lib/jenkins/workspace/openshift-managed-node-metadata-operator-gh-build-main'
11:32:21 make: *** [build-push] Error 2
11:32:21 Build step 'Execute shell' marked build as failure
11:32:21 Finished: FAILURE
```