### PR TITLE
[OSD-13201] Add new metric for use in MNMO alert for failures.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.20.2
 	github.com/openshift/api v3.9.0+incompatible
+	github.com/prometheus/client_golang v1.11.0
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
@@ -36,7 +37,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,18 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	NodeReconciliationFailure = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:        "mnmo_node_reconciliation_failure",
+		Help:        "Reconciliation failures occuring when updating a specific node",
+		ConstLabels: map[string]string{},
+	}, []string{"node"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(NodeReconciliationFailure)
+}


### PR DESCRIPTION
The currently used metric is only checking failures for reconciliation in general, which leads to alerts being triggered, when different nodes fail reconciliation.

This can however happen during upgrades and is no reason to alert, so instead add a new metrics for per-node reconciliation failures.

This PR is to showcase one possible solution for [OSD-13201](https://issues.redhat.com//browse/OSD-13201).