### PR TITLE
[OSD-13432] Explicitly name the controller.

### DIFF
--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -232,5 +232,6 @@ func (r MachinesetReconciler) updateTaintsInNode(ctx context.Context, machine *m
 func (r *MachinesetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&machinev1.MachineSet{}).
+		Named("machineset_controller").
 		Complete(r)
 }


### PR DESCRIPTION
This is to ensure our metrics still work, instead of implicitly changing the controller name to the `kind` of the reconciled type.