### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This managed-node-metadata-operator will attempt to watch MachineSet objects and
 
 ```mermaid
 flowchart TD
-    A[User updates MachineSet in OCM] --> B[Hive applies changes to MachineSet on cluster]
+    A[User updates MachinePool in OCM] --> B[Hive applies changes to MachineSet on cluster]
     B --> C;
     subgraph Managed Node Metadata Operator
       C[MNMO Picks up change to MachineSet and begins reconcile] --> D[Loop through all Machines in Machineset and Sync Label/Taint changes];


### PR DESCRIPTION
In the flowchart, change `User updates MachineSet in OCM` to `User updates MachinePool in OCM`

OCM has no knowledge of MachineSets. Users are actually editing MachinePools in there.