### PR TITLE
Ignore NoSchedule taints when reconciling node taints

### DIFF
--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	machinev1 "github.com/openshift/api/machine/v1beta1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	m "github.com/openshift/managed-node-metadata-operator/pkg/machine"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,9 +27,9 @@ type mocks struct {
 
 var _ = Describe("MachinesetController", func() {
 	var (
-		machineSet     machinev1.MachineSet
-		machine        machinev1.Machine
-		updatedMachine machinev1.Machine
+		machineSet     machinev1beta1.MachineSet
+		machine        machinev1beta1.Machine
+		updatedMachine machinev1beta1.Machine
 		node           corev1.Node
 		updatedNode    corev1.Node
 		mockObjects    *mocks
@@ -43,7 +43,7 @@ var _ = Describe("MachinesetController", func() {
 	if err := corev1.AddToScheme(s); err != nil {
 		fmt.Printf("failed adding apis to scheme in machineset controller tests")
 	}
-	if err := machinev1.AddToScheme(s); err != nil {
+	if err := machinev1beta1.AddToScheme(s); err != nil {
 		fmt.Printf("failed adding apis to scheme in machineset controller tests")
 	}
 
@@ -60,32 +60,32 @@ var _ = Describe("MachinesetController", func() {
 		})
 
 		JustBeforeEach(func() {
-			machineSet = machinev1.MachineSet{
+			machineSet = machinev1beta1.MachineSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test machineset",
 					Namespace: "test",
 				},
-				Spec: machinev1.MachineSetSpec{
+				Spec: machinev1beta1.MachineSetSpec{
 					Selector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"owner": "fake-machineset",
 						},
 					},
-					Template: machinev1.MachineTemplateSpec{
-						ObjectMeta: machinev1.ObjectMeta{
+					Template: machinev1beta1.MachineTemplateSpec{
+						ObjectMeta: machinev1beta1.ObjectMeta{
 							Labels: map[string]string{
 								"owner": "fake-machineset",
 							},
 						},
-						Spec: machinev1.MachineSpec{
-							ObjectMeta: machinev1.ObjectMeta{
+						Spec: machinev1beta1.MachineSpec{
+							ObjectMeta: machinev1beta1.ObjectMeta{
 								Labels: newLabelsInMachineSet,
 							},
 						},
 					},
 				},
 			}
-			machine = machinev1.Machine{
+			machine = machinev1beta1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test machine",
 					Namespace: "test",
@@ -93,12 +93,12 @@ var _ = Describe("MachinesetController", func() {
 						"owner": "fake-machineset",
 					},
 				},
-				Spec: machinev1.MachineSpec{
-					ObjectMeta: machinev1.ObjectMeta{
+				Spec: machinev1beta1.MachineSpec{
+					ObjectMeta: machinev1beta1.ObjectMeta{
 						Labels: existingLabelsInMachine,
 					},
 				},
-				Status: machinev1.MachineStatus{
+				Status: machinev1beta1.MachineStatus{
 					NodeRef: &corev1.ObjectReference{
 						Name: "test-node",
 					},
@@ -233,34 +233,34 @@ var _ = Describe("MachinesetController", func() {
 		})
 
 		JustBeforeEach(func() {
-			machineSet = machinev1.MachineSet{
+			machineSet = machinev1beta1.MachineSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test machineset",
 					Namespace: "test",
 				},
-				Spec: machinev1.MachineSetSpec{
-					Template: machinev1.MachineTemplateSpec{
-						Spec: machinev1.MachineSpec{
+				Spec: machinev1beta1.MachineSetSpec{
+					Template: machinev1beta1.MachineTemplateSpec{
+						Spec: machinev1beta1.MachineSpec{
 							Taints: newTaintsInMachineSet,
 						},
 					},
 				},
 			}
-			machine = machinev1.Machine{
+			machine = machinev1beta1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test machineset",
 					Namespace: "test",
 				},
-				Spec: machinev1.MachineSpec{
+				Spec: machinev1beta1.MachineSpec{
 					Taints: existingTaintsInMachine,
 				},
 			}
-			updatedMachine = machinev1.Machine{
+			updatedMachine = machinev1beta1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test machineset",
 					Namespace: "test",
 				},
-				Spec: machinev1.MachineSpec{
+				Spec: machinev1beta1.MachineSpec{
 					Taints: updatedTaintsInMachine,
 				},
 			}
@@ -354,13 +354,13 @@ var _ = Describe("MachinesetController", func() {
 		)
 
 		JustBeforeEach(func() {
-			machine = machinev1.Machine{
+			machine = machinev1beta1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test machine",
 					Namespace: "test",
 				},
-				Spec: machinev1.MachineSpec{
-					ObjectMeta: machinev1.ObjectMeta{
+				Spec: machinev1beta1.MachineSpec{
+					ObjectMeta: machinev1beta1.ObjectMeta{
 						Labels: newLabelsInMachine,
 					},
 				},
@@ -449,12 +449,12 @@ var _ = Describe("MachinesetController", func() {
 			}
 		})
 		JustBeforeEach(func() {
-			machine = machinev1.Machine{
+			machine = machinev1beta1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test machine",
 					Namespace: "test",
 				},
-				Spec: machinev1.MachineSpec{
+				Spec: machinev1beta1.MachineSpec{
 					Taints: newTaintsInMachine,
 				},
 			}
@@ -510,6 +510,31 @@ var _ = Describe("MachinesetController", func() {
 						Effect: corev1.TaintEffectPreferNoSchedule,
 						Value:  "bar",
 						Key:    "foo",
+					},
+				}
+			})
+
+			It("should update taints in node", func() {
+				err = r.updateTaintsInNode(ctx, &machine, &node)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(node.Spec.Taints).To(Equal(updatedNode.Spec.Taints))
+			})
+		})
+
+		Context("When a NoSchedule taint is added to the node", func() {
+
+			BeforeEach(func() {
+				newTaintsInMachine = []corev1.Taint{}
+				existingTaintsInNode = []corev1.Taint{
+					{
+						Key:    corev1.TaintNodeUnschedulable,
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				}
+				updatedTaintsInNode = []corev1.Taint{
+					{
+						Key:    corev1.TaintNodeUnschedulable,
+						Effect: corev1.TaintEffectNoSchedule,
 					},
 				}
 			})


### PR DESCRIPTION
These taints can be set by other operators such as machine-config-operator and should not be removed by this operator as it can directly interfere with the OCP upgrade process by resetting the timer for PodDisruptionBudget drain timeouts.

[OSD-16434](https://issues.redhat.com//browse/OSD-16434)

## Checklist before requesting review

- [x] I have tested this locally
- [x] I have included unit tests
- [x] I have updated any corresponding documentation