### PR TITLE
[AUTH-388] hack/olm-registry: set pod security admission labels in olm-artifacts-template.yaml

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -36,6 +36,9 @@ objects:
       metadata:
         labels:
           openshift.io/cluster-monitoring: 'true'
+          pod-security.kubernetes.io/enforce: 'baseline'
+          pod-security.kubernetes.io/audit: 'baseline'
+          pod-security.kubernetes.io/warn: 'baseline'
         name: ${NAMESPACE}
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup


### PR DESCRIPTION
# What is being added?
This sets pod security admission labels. Currently, none are set and starting with OpenShift 4.13 this generates warnings in Telemetry. This fixes it.

Refer to https://kubernetes.io/docs/concepts/security/pod-security-standards/ to further tighten the labels potentially to the recommended `restricted` level.

The labels were determined by using the https://github.com/stlaz/psachecker tool.

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe alerts in the OpenShift cluster, firing `PodSecurityViolation{ocp_namespace="openshift-managed-node-metadata-operator",policy_level="restricted"}`
