### PR TITLE
Prefer scheduling registry pod onto infra nodes

### DIFF
--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -3,7 +3,7 @@ ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.8-1
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8-3
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -63,6 +63,14 @@ objects:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         publisher: Red Hat
         sourceType: grpc
+        grpcPodConfig:
+          securityContextConfig: restricted
+          nodeSelector:
+            node-role.kubernetes.io: infra
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/infra
+            operator: Exists
     - apiVersion: operators.coreos.com/v1alpha1
       kind: Subscription
       metadata:


### PR DESCRIPTION
This commit specifies .spec.grpcPodConfig.nodeSelector and .spec.grpdPodConfig.tolerations to schedule this operator's registry pod to infra nodes when possible.

[OSD-6629](https://issues.redhat.com//browse/OSD-6629)