### PR TITLE
fixed osde2e image url in e2e template

### DIFF
--- a/osde2e/test-harness-template.yml
+++ b/osde2e/test-harness-template.yml
@@ -29,7 +29,7 @@ objects:
           restartPolicy: Never
           containers:
             - name: osde2e
-              image: quay.io/app-sre:latest
+              image: quay.io/app-sre/osde2e:latest
               command:
                 - /osde2e
               args:


### PR DESCRIPTION
# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

fix 


- IT fixes the path to osde2e image https://quay.io/repository/app-sre/osde2e in test harness template

[sdcicd-1075](https://issues.redhat.com//browse/sdcicd-1075) 
## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1.  

Ref [sdcicd-1075](https://issues.redhat.com//browse/sdcicd-1075) 
