### PR TITLE
updating e2e openshift resource template

### DIFF
--- a/osde2e/test-harness-template.yml
+++ b/osde2e/test-harness-template.yml
@@ -3,19 +3,21 @@ apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: osde2e-focused-tests
-labels:
-  template: osde2e-focused-tests
+
 parameters:
   - name: HARNESS_IMAGE_TAG
-    displayName: Test harness image Tag
+    required: true
   - name: OSDE2E_CONFIGS
-    displayName: osde2e Configs
-    description: pre-baked configuration from the osde2e repository
-    value: rosa,stage,test-harness
-  - name: EXTRA_ARGS
-    displayName: Additonal args to supply to osde2e
+    required: true
   - name: TEST_HARNESS_IMAGE
-    displayName: Test Harness Image(s)
+    required: true
+  - name: OCM_TOKEN
+    required: true
+  - name: AWS_ACCESS_KEY_ID
+    required: true    
+  - name: AWS_SECRET_ACCESS_KEY
+    required: true
+  - name: AWS_REGION
     required: true
 objects:
   - apiVersion: batch/v1
@@ -36,7 +38,6 @@ objects:
                 - test
                 - --configs
                 - ${OSDE2E_CONFIGS}
-                - ${EXTRA_ARGS}
               securityContext:
                 runAsNonRoot: true
                 allowPrivilegeEscalation: false


### PR DESCRIPTION
# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

openshift resource template for e2e tekton job is failing as template is invalid. This change tweaks the template for possibly invalid values. 

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref  SDCICD_1075
