### PR TITLE
[OSD-18419] Add NodeReconciliationFailure metric test

### DIFF
--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -90,7 +90,7 @@ func (r *MachinesetReconciler) ProcessMachineSet(ctx context.Context, machineSet
 		node, err := m.GetNodeForMachine(r.Client, machine)
 		if err != nil {
 			klog.Errorf("failed to fetch node for machine %s", machine.Name)
-			metrics.NodeReconciliationFailure.WithLabelValues(machine.Name).Add(1.0)
+			metrics.IncreaseNodeReconciliationFailure(machine.Name)
 			return reconcile.Result{}, err
 		}
 		expectedLabels := r.getExpectedLabels(ctx, machineSet, machine, node)
@@ -100,25 +100,25 @@ func (r *MachinesetReconciler) ProcessMachineSet(ctx context.Context, machineSet
 		// Update labels in machine
 		err = r.updateLabelsInMachine(ctx, machine, expectedLabels)
 		if err != nil {
-			metrics.NodeReconciliationFailure.WithLabelValues(node.Name).Add(1.0)
+			metrics.IncreaseNodeReconciliationFailure(node.Name)
 			return reconcile.Result{}, err
 		}
 		// Update taints in machine
 		err = r.updateTaintsInMachine(ctx, machineSet, machine)
 		if err != nil {
-			metrics.NodeReconciliationFailure.WithLabelValues(node.Name).Add(1.0)
+			metrics.IncreaseNodeReconciliationFailure(node.Name)
 			return reconcile.Result{}, err
 		}
 		//Update labels in node
 		err = r.updateLabelsInNode(ctx, node, expectedLabels)
 		if err != nil {
-			metrics.NodeReconciliationFailure.WithLabelValues(node.Name).Add(1.0)
+			metrics.IncreaseNodeReconciliationFailure(node.Name)
 			return reconcile.Result{}, err
 		}
 		// Update taints in node
 		err = r.updateTaintsInNode(ctx, machine, node)
 		if err != nil {
-			metrics.NodeReconciliationFailure.WithLabelValues(node.Name).Add(1.0)
+			metrics.IncreaseNodeReconciliationFailure(node.Name)
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,3 +16,8 @@ var (
 func init() {
 	metrics.Registry.MustRegister(NodeReconciliationFailure)
 }
+
+// IncreaseNodeReconciliationFailure Adds 1
+func IncreaseNodeReconciliationFailure(node string) {
+	NodeReconciliationFailure.WithLabelValues(node).Add(1.0)
+}

--- a/pkg/metrics/metrics_suite_test.go
+++ b/pkg/metrics/metrics_suite_test.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,61 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Webhook Handlers", func() {
+
+	var (
+		testNodename = "test-nodename"
+		server       *ghttp.Server
+	)
+
+	BeforeEach(func() {
+		resetMetrics()
+		server = ghttp.NewServer()
+	})
+	AfterEach(func() {
+		server.Close()
+	})
+
+	Context("Service Log Sent metric", func() {
+		var (
+			metricHelpHeader = `
+# HELP mnmo_node_reconciliation_failure Reconciliation failures occuring when updating a specific node
+# TYPE mnmo_node_reconciliation_failure counter
+`
+			metricValueHeader = fmt.Sprintf(`mnmo_node_reconciliation_failure{node="%s"} `, testNodename)
+		)
+		When("the metric is set once", func() {
+			It("does so correctly", func() {
+				IncreaseNodeReconciliationFailure(testNodename)
+				expectedMetric := fmt.Sprintf("%s%s%d\n", metricHelpHeader, metricValueHeader, 1)
+				err := testutil.CollectAndCompare(NodeReconciliationFailure, strings.NewReader(expectedMetric))
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("the metric is set twice", func() {
+			It("increments the metric", func() {
+				IncreaseNodeReconciliationFailure(testNodename)
+				IncreaseNodeReconciliationFailure(testNodename)
+				expectedMetric := fmt.Sprintf("%s%s%d\n", metricHelpHeader, metricValueHeader, 2)
+				err := testutil.CollectAndCompare(NodeReconciliationFailure, strings.NewReader(expectedMetric))
+				Expect(err).To(BeNil())
+			})
+		})
+
+	})
+})
+
+func resetMetrics() {
+	NodeReconciliationFailure.Reset()
+}


### PR DESCRIPTION
# What is being added?
ginkgo test for NodeReconciliationFailure metric

## Checklist before requesting review

- [x] I have tested this locally
- [x] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. ./boilerplate/_lib/container-make test
2.  verify 
```
?   	github.com/openshift/managed-node-metadata-operator	[no test files]
?   	github.com/openshift/managed-node-metadata-operator/config	[no test files]
ok  	github.com/openshift/managed-node-metadata-operator/controllers	0.023s
ok  	github.com/openshift/managed-node-metadata-operator/pkg/machine	0.018s
ok  	github.com/openshift/managed-node-metadata-operator/pkg/metrics	0.016s

```
Ref [OSD-18419](https://issues.redhat.com//browse/OSD-18419)
