### PR TITLE
added suffix to harness job name in template

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=mod -a -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/osde2e/test-harness-template.yml
+++ b/osde2e/test-harness-template.yml
@@ -19,12 +19,14 @@ parameters:
     required: true
   - name: AWS_REGION
     required: true
+  - name: JOBID
+    generate: expression
+    from: "[0-9a-z]{7}"
 objects:
   - apiVersion: batch/v1
     kind: Job
     metadata:
-      generateName: osde2e-focused-tests-
-      name: osde2e-focused-test-job
+      name: osde2e-focused-test-job-${HARNESS_IMAGE_TAG}-${JOBID}
     spec:
       backoffLimit: 0
       template:


### PR DESCRIPTION
# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

added suffix to e2e job tekton template. Suffix will allow force running multiple jobs on same image tag if needed

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref  [sdcicd-1075](https://issues.redhat.com//browse/sdcicd-1075)
