### PR TITLE
remove HARNESS_IMAGE_TAG, use existing IMAGE_TAG var

### DIFF
--- a/osde2e/test-harness-template.yml
+++ b/osde2e/test-harness-template.yml
@@ -5,8 +5,6 @@ metadata:
   name: osde2e-focused-tests
 
 parameters:
-  - name: HARNESS_IMAGE_TAG
-    required: true
   - name: OSDE2E_CONFIGS
     required: true
   - name: TEST_HARNESS_IMAGE
@@ -53,7 +51,7 @@ objects:
                   type: RuntimeDefault
               env:
                 - name: TEST_HARNESSES
-                  value: ${TEST_HARNESS_IMAGE}:${HARNESS_IMAGE_TAG}
+                  value: ${TEST_HARNESS_IMAGE}:${IMAGE_TAG}
                 - name: OCM_TOKEN
                   value: ${OCM_TOKEN}
                 - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

fix for saas pipeline not evaluating HARNESS_IMAGE_TAG correctly

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref [sdcicd-1075](https://issues.redhat.com//browse/sdcicd-1075)
