### PR TITLE
increase e2e harness timeout

### DIFF
--- a/osde2e/test-harness-template.yml
+++ b/osde2e/test-harness-template.yml
@@ -63,4 +63,6 @@ objects:
                 - name: AWS_REGION
                   value: ${AWS_REGION}
                 - name: LOG_BUCKET
-                  value: ${LOG_BUCKET}                 
+                  value: ${LOG_BUCKET}   
+                - name: HARNESS_TIMEOUT
+                  value: 600


### PR DESCRIPTION
# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

increase e2e test timeout  since tests are taking 500+ seconds after bp update. default timeout is 300s. 

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
