### PR TITLE
[OSD-17970] Handle duplicate taints.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=mod -a -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -582,5 +582,34 @@ var _ = Describe("MachinesetController", func() {
 			})
 		})
 
+		Context("When a duplicate taint is added", func() {
+			BeforeEach(func() {
+				newTaintsInMachine = []corev1.Taint{
+					corev1.Taint{
+						Key:    "test",
+						Value:  "test",
+						Effect: "NoSchedule",
+					},
+					corev1.Taint{
+						Key:    "test",
+						Value:  "test",
+						Effect: "NoSchedule",
+					},
+				}
+				existingTaintsInNode = []corev1.Taint{}
+				updatedTaintsInNode = []corev1.Taint{
+					corev1.Taint{
+						Key:    "test",
+						Value:  "test",
+						Effect: "NoSchedule",
+					},
+				}
+			})
+			It("it should update the node, but indicate the error", func() {
+				err = r.updateTaintsInNode(ctx, &machine, &node)
+				Expect(err).To(HaveOccurred())
+				Expect(node.Spec.Taints).To(Equal(updatedNode.Spec.Taints))
+			})
+		})
 	})
 })


### PR DESCRIPTION
Each taint will only be applied once, but the existance of dupliate taints will be logged.

# What is being added?

Handle duplicate taints without printing big error stacktraces.

## Checklist before requesting review

- [X] I have tested this locally
- [X] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
