### PR TITLE
Allow osde2e test to work on GCP

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=mod -a -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/osde2e/managed_node_metadata_operator_tests.go
+++ b/osde2e/managed_node_metadata_operator_tests.go
@@ -57,7 +57,11 @@ var _ = ginkgo.Describe("managed-node-metadata-operator", ginkgo.Ordered, func()
 		Expect(err).ShouldNot(HaveOccurred(), "unable to setup k8s client")
 
 		machinepoolName = envconf.RandomName("osde2e", 10)
-		machinepoolBuilder := clustersmgmtv1.NewMachinePool().ID(machinepoolName).InstanceType("m5.xlarge").Replicas(machinepoolReplicaCount)
+		var instanceType = "m5.xlarge"
+		if cluster.CloudProvider().ID() == "gcp" {
+			instanceType = "c2-standard-4"
+		}
+		machinepoolBuilder := clustersmgmtv1.NewMachinePool().ID(machinepoolName).InstanceType(instanceType).Replicas(machinepoolReplicaCount)
 		machinepool, err := machinepoolBuilder.Build()
 		Expect(err).Should(BeNil(), "machinepoolBuilder.Build failed")
 		_, err = ocmClusterClient.MachinePools().Add().Body(machinepool).SendContext(ctx)


### PR DESCRIPTION
# What is being added?
I'm working on 4.15 gap analysis and trying to get CI green. It's likely never worked on OSD GCP before, so it's somewhat of a bugfix :D

https://testgrid.k8s.io/redhat-openshift-ocp-release-4.15-informing#periodic-ci-openshift-osde2e-main-nightly-4.15-osd-gcp

Currently, the output is:
```
      Expected
          <*errors.Error | 0xc000413f10>: 
          status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is 'e81edf7e-de75-4189-889a-24f58c6fc31e': Machine type 'm5.xlarge' is not supported for cloud provider 'gcp'
          {
              bitmap_: 63,
              status: 400,
              id: "400",
              href: "/api/clusters_mgmt/v1/errors/400",
              code: "CLUSTERS-MGMT-400",
              reason: "Machine type 'm5.xlarge' is not supported for cloud provider 'gcp'",
              details: nil,
              operationID: "e81edf7e-de75-4189-889a-24f58c6fc31e",
          }
      to be nil
```

[OSD-20366](https://issues.redhat.com//browse/OSD-20366)
