### PR TITLE
Fix bug with GCP osde2e where c2-standard-4 is not supported for non-CCS clusters

### DIFF
--- a/osde2e/managed_node_metadata_operator_tests.go
+++ b/osde2e/managed_node_metadata_operator_tests.go
@@ -59,7 +59,9 @@ var _ = ginkgo.Describe("managed-node-metadata-operator", ginkgo.Ordered, func()
 		machinepoolName = envconf.RandomName("osde2e", 10)
 		var instanceType = "m5.xlarge"
 		if cluster.CloudProvider().ID() == "gcp" {
-			instanceType = "c2-standard-4"
+			// https://docs.openshift.com/dedicated/osd_architecture/osd_policy/osd-service-definition.html#gcp-compute-types_osd-service-definition
+			// In osde2e, this is a non-CCS OSD GCP cluster with very limited instance type support
+			instanceType = "custom-4-16384"
 		}
 		machinepoolBuilder := clustersmgmtv1.NewMachinePool().ID(machinepoolName).InstanceType(instanceType).Replicas(machinepoolReplicaCount)
 		machinepool, err := machinepoolBuilder.Build()


### PR DESCRIPTION
Related to #93, except I didn't know this ran on a non-CCS GCP cluster and was testing on CCS instead :(

The latest osde2e run: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.15-osd-gcp/1750230608778366976

with error:
```
[FAILED] failed to create machinepool
      Expected
          <*errors.Error | 0xc0000d8460>: 
          status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is '332762e3-36ef-4929-85ce-8b549e65e80a': Machine type 'c2-standard-4' is only supported for CCS clusters
          {
              bitmap_: 63,
              status: 400,
              id: "400",
              href: "/api/clusters_mgmt/v1/errors/400",
              code: "CLUSTERS-MGMT-400",
              reason: "Machine type 'c2-standard-4' is only supported for CCS clusters",
              details: nil,
              operationID: "332762e3-36ef-[492](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.15-osd-gcp/1750230608778366976#1:build-log.txt%3A492)9-85ce-8b549e65e80a",
          }
      to be nil
```

OSD-20366
