### PR TITLE
Increase timeout to 5 minutes.

### DIFF
--- a/osde2e/managed_node_metadata_operator_tests.go
+++ b/osde2e/managed_node_metadata_operator_tests.go
@@ -138,7 +138,7 @@ var _ = ginkgo.Describe("managed-node-metadata-operator", ginkgo.Ordered, func()
 		Expect(err).Should(BeNil(), "failed to build machinepool with labels")
 		_, err = ocmClusterClient.MachinePools().MachinePool(machinepoolName).Update().Body(machinepool).SendContext(ctx)
 		Expect(err).Should(BeNil(), "failed to update machinepool labels")
-		Expect(wait.For(nodesTo(ctx, lbls, haveLabels), wait.WithTimeout(2*time.Minute))).Should(BeNil(), "waiting for labels to be synced failed")
+		Expect(wait.For(nodesTo(ctx, lbls, haveLabels), wait.WithTimeout(5*time.Minute))).Should(BeNil(), "waiting for labels to be synced failed")
 	},
 		ginkgo.Entry("added", map[string]string{"osde2e": "one"}),
 		ginkgo.Entry("updated", map[string]string{"osde2e": "two"}),

--- a/osde2e/test-harness-template.yml
+++ b/osde2e/test-harness-template.yml
@@ -65,4 +65,4 @@ objects:
                 - name: LOG_BUCKET
                   value: ${LOG_BUCKET}   
                 - name: HARNESS_TIMEOUT
-                  value: "600"
+                  value: "900"


### PR DESCRIPTION
Hives have way more MachinePools now so maybe syncing might take a bit longer.

# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
