### PR TITLE
Add mmazur as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,4 +12,5 @@ reviewers:
 - dkeohane
 - AlexVulaj
 - bergmannf
+- mmazur
 maintainers:


### PR DESCRIPTION
**What**: Add me as an approver, so I can review and merge pipeline- and test-specific PRs without involving the primary approvers.

**Why**: so you don't have to review all the changes to tests and pipelines that are coming soon. I'll do it for you.

**Why (longer)**: there are things coming over the next few quarters (e.g. Progressive Delivery, konflux) that will involve changes to tests and pipelines of all the operators. Historically such changes were an issue to get merged, since reviewers typically had little context (or time) for them. So recently we've tried a different approach: I got added as an approver for boilerplate and MGO and whenever Cicada makes changes to them, I review and merge them. This is working much better than it used to, so we're extending this approach to the remaining osd operator repos in expectation of the boatload of PRs soon to come.

**How risky is this**: not at all, since we don't make functional changes to the operators. And I will not be looking at PRs outside of our jurisdiction.


Ref [SDCICD-1368](https://issues.redhat.com//browse/SDCICD-1368)