### PR TITLE
Update e2e tests to retrieve OCM env from envvar.

### DIFF
--- a/test/e2e/managed_node_metadata_operator_tests.go
+++ b/test/e2e/managed_node_metadata_operator_tests.go
@@ -38,7 +38,18 @@ var _ = ginkgo.Describe("managed-node-metadata-operator", ginkgo.Ordered, func()
 		clusterID = os.Getenv("OCM_CLUSTER_ID")
 		Expect(clusterID).ShouldNot(BeEmpty(), "OCM_CLUSTER_ID is required but not set")
 
-		ocmConn, err := ocm.New(ctx, os.Getenv("OCM_TOKEN"), ocm.Stage)
+		var ocmUrl ocm.Environment
+
+		switch os.Getenv("OCM_ENV") {
+		case "stage":
+			ocmUrl = ocm.Stage
+		case "int":
+			ocmUrl = ocm.Integration
+		default:
+			ginkgo.Fail("Unexpected OCM_ENV - use 'stage' or 'int'")
+		}
+
+		ocmConn, err := ocm.New(ctx, os.Getenv("OCM_TOKEN"), ocmUrl)
 		Expect(err).ShouldNot(HaveOccurred(), "unable to setup ocm client")
 		ginkgo.DeferCleanup(ocmConn.Connection.Close)
 


### PR DESCRIPTION
# What is being added?

E2E tests no longer only run against stage, so the environment should be set based on the env variable.

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
