### PR TITLE
Removed random `time.Sleep` in favor of managed k8s `wait.For`

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=mod -a -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
# What is being added?
Fix for a potential bug

Having arbitrary sleeps is much more brittle than waiting on a specific resource.  Let's use a library function from the Kubernetes author like is done in many other of our test suites.

## Checklist before requesting review

- [ x] I have tested this locally

## Steps To Manually Test

```
$ cd managed-node-metadata-operator/test/e2e
$ OCM_TOKEN=$(ocm token) OCM_CLUSTER_ID=2iep1m2q79usmnolvj6tpuhfarvoi76g OCM_ENV=stage DISABLE_JUNIT_REPORT=true ginkgo run --tags=osde2e,e2e --procs 4 --flake-attempts 3 --trace -vv .
```

Ref [OSD-29388](https://issues.redhat.com//browse/OSD-29388)
