### PR TITLE
Resources must be an array.

### DIFF
--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -31,11 +31,11 @@ objects:
           api.openshift.com/managed: "true"
       resourceApplyMode: Sync
       resources:
-        apiVersion: package-operator.run/v1alpha1
-        kind: ClusterPackage
-        metadata:
-          name: "${REPO_NAME}"
-          annotations:
-            package-operator.run/collision-protection: IfNoController
-        spec:
-          image: ${PKO_IMAGE}:${IMAGE_TAG}
+        - apiVersion: package-operator.run/v1alpha1
+          kind: ClusterPackage
+          metadata:
+            name: "${REPO_NAME}"
+            annotations:
+              package-operator.run/collision-protection: IfNoController
+          spec:
+            image: ${PKO_IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
# What is being added?

The selectorsyncset contains an array under `spec.resources` not a single object.

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation
