### PR TITLE
test/e2e: disable upgrade test

### DIFF
--- a/test/e2e/managed_node_metadata_operator_tests.go
+++ b/test/e2e/managed_node_metadata_operator_tests.go
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("managed-node-metadata-operator", ginkgo.Ordered, func()
 		ginkgo.Entry("deleted", map[string]string{}),
 	)
 
-	ginkgo.It("can be upgraded", func(ctx context.Context) {
+	ginkgo.PIt("can be upgraded", func(ctx context.Context) {
 		err := k8s.UpgradeOperator(ctx, config.OperatorName, config.OperatorNamespace)
 		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
 	})


### PR DESCRIPTION
# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

this will fail during the PKO migration since the upgrade tests are looking for the OLM Subscription

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
