### PR TITLE
OSD-30680: Adding Konflux .tekton pipelines for push and pull events

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- srep-infra-cicd
+approvers:
+- srep-infra-cicd

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=mod -a -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1751443646
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1753764099
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1751443646
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1753764099
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/build/Dockerfile.pko
+++ b/build/Dockerfile.pko
@@ -1,3 +1,13 @@
 FROM scratch
 
 COPY * /package/
+
+LABEL \
+        io.k8s.description="This is a component of managed-node-metadata-operator for pko." \
+        com.redhat.component="managed-node-metadata-operator-pko" \
+        maintainer="" \
+        name="openshift/managed-node-metadata-operator" \
+        License="NA" \
+        io.k8s.display-name="Managed Node Metadata Operator" \
+        vendor="Red Hat" \
+        io.openshift.tags="openshift,managed-node-metadata-operator,MNMO"


### PR DESCRIPTION
# What is being added?
Adding Konflux .tekton pipelines for push and pull events
Adding Konflux .tekton build trigger expression
Adding renovate config file that is configured to auto merge bumps to the .tekton pipelines (Konflux build)
Updating registry.access.redhat.com/ubi8/ubi-minimal with latest version

## Checklist before requesting review

- [x] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
Please find the pipeline runs
https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/managed-node-metadata-operator-tenant/applications/managed-node-metadata-operator/activity/pipelineruns

## Steps To Manually Test
Make sure the automated PR's created(open state) for .tekton pipelines (Konflux build)
verify the image released under konflux
https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/managed-node-metadata-operator-tenant/applications/managed-node-metadata-operator/releases

Ref [OSD-30680](https://issues.redhat.com//browse/OSD-30680)
