### PR TITLE
OSD-30779: Removing the on-cel-expression for tekton files

### DIFF
--- a/.tekton/managed-node-metadata-operator-e2e-pull-request.yaml
+++ b/.tekton/managed-node-metadata-operator-e2e-pull-request.yaml
@@ -8,13 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" 
-      && target_branch == "main"
-      && ("{.,**}/*.go".pathChanged() ||
-          "{.,**}/go.*".pathChanged() ||
-          "test/e2e/Dockerfile".pathChanged() ||
-          ".tekton/managed-node-metadata-operator-e2e-pull-request.yaml".pathChanged() )  
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: managed-node-metadata-operator

--- a/.tekton/managed-node-metadata-operator-e2e-push.yaml
+++ b/.tekton/managed-node-metadata-operator-e2e-push.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" 
-      && target_branch == "main"
-      && ("{.,**}/*.go".pathChanged() ||
-          "{.,**}/go.*".pathChanged() ||
-          "test/e2e/Dockerfile".pathChanged() ||
-          ".tekton/managed-node-metadata-operator-e2e-push.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: managed-node-metadata-operator

--- a/.tekton/managed-node-metadata-operator-pull-request.yaml
+++ b/.tekton/managed-node-metadata-operator-pull-request.yaml
@@ -8,13 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" 
-      && target_branch == "main"
-      && ("**/*.go".pathChanged() ||
-          "**/go.*".pathChanged() ||
-          "build/Dockerfile".pathChanged() ||
-          ".tekton/managed-node-metadata-operator-pull-request.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: managed-node-metadata-operator

--- a/.tekton/managed-node-metadata-operator-push.yaml
+++ b/.tekton/managed-node-metadata-operator-push.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" 
-      && target_branch == "main"
-      && ("**/*.go".pathChanged() ||
-          "**/go.*".pathChanged() ||
-          "build/Dockerfile".pathChanged() ||
-          ".tekton/managed-node-metadata-operator-push.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: managed-node-metadata-operator


### PR DESCRIPTION
# What is being added?
Fix for a bug (Removing the on-cel-expression to build both controller and e2e components for each commit)

## Checklist before requesting review

- [X] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
Make sure the konflux build triggered for both controller and e2e components.

Ref [OSD-30779](https://issues.redhat.com//browse/OSD-30779)
