### PR TITLE
The -registry pod is managed by the catalogsource.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=mod -a -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1770267347
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1770267347
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy_pko/Cleanup-Deployment.yaml
+++ b/deploy_pko/Cleanup-Deployment.yaml
@@ -27,7 +27,8 @@ spec:
             - |
               #!/bin/sh
               set -euxo pipefail
-              oc -n openshift-managed-node-metadata-operator delete csv -l "operators.coreos.com/managed-node-metadata-operator.openshift-managed-node-metadata"
+              oc -n openshift-managed-node-metadata-operator delete csv -l "operators.coreos.com/managed-node-metadata-operator.openshift-managed-node-metadata" || true
+              oc -n openshift-managed-node-metadata-operator delete catalogsource managed-node-metadata-operator-registry || true
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/Cleanup-Role.yaml
+++ b/deploy_pko/Cleanup-Role.yaml
@@ -12,6 +12,7 @@ rules:
     resources:
       - "clusterserviceversions"
       - "subscriptions"
+      - "catalogsource"
     verbs:
       - list
       - get


### PR DESCRIPTION
When using PKO make sure the cleanup also removes the catalogsource.

# What is being added?

Bug fix - the PKO cronjob to cleanup old OLM resources did not cleanup the catalogsource.

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
