### PR TITLE
chore: update all OLM template SSSs to Upsert

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -29,7 +29,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: Namespace


### PR DESCRIPTION
# What is being added?

Updates all SelectorSyncSets in the OLM template to `resourceApplyMode: Upsert`.
This will allow a safe transition to PKO when the old SelectorSyncSets are deleted.
When in `Upsert` mode Hive orphans the resources applied to clusters matching the SelectorSyncSet rather than deleting them when the SelectorSyncSet is deleted.

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

